### PR TITLE
Correções no modelo Employee

### DIFF
--- a/drdown/users/admin.py
+++ b/drdown/users/admin.py
@@ -49,3 +49,8 @@ class MyUserAdmin(AuthUserAdmin):
     ) + AuthUserAdmin.fieldsets
     list_display = ('username', 'name', 'is_superuser')
     search_fields = ['name']
+
+
+@admin.register(Employee)
+class EmployeeAdmin(admin.ModelAdmin):
+    change_form_template = "admin/change_form.html"

--- a/drdown/users/tests/test_model_employee.py
+++ b/drdown/users/tests/test_model_employee.py
@@ -78,9 +78,10 @@ class TestModelEmployeeNoSetUp(TestCase):
             add=True
         )
 
-        self.assertEqual(
-            employee_group.permissions,
-            employee_group.permissions
+        self.assertQuerysetEqual(
+            employee_group.permissions.all(),
+            mock_group.permissions.all(),
+            transform=lambda x: x
         )
 
         # and change things in the user
@@ -89,4 +90,27 @@ class TestModelEmployeeNoSetUp(TestCase):
         self.assertEqual(
             self.user.groups.get(name=Employee.GROUP_NAME),
             employee_group
+        )
+
+    def test_permission_set(self):
+
+        # this will be tested with the Patient model
+        content_type = ContentType.objects.get_for_model(Patient)
+ 
+        mock_group = Group.objects.create(name="mock")
+
+        # adds all permissions avaliable in set_permissions
+        set_permissions(
+            Patient,
+            mock_group,
+            change=True,
+            add=True,
+            delete=True
+        )
+
+        # check if the where added
+        self.assertQuerysetEqual(
+            Permission.objects.filter(content_type=content_type), 
+            mock_group.permissions.all(),
+            transform=lambda x: x
         )

--- a/drdown/users/tests/test_model_employee.py
+++ b/drdown/users/tests/test_model_employee.py
@@ -1,15 +1,20 @@
 from test_plus.test import TestCase
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission, ContentType
 
 
-from ..models import Employee
+from ..models import Employee, Patient, Responsible
+from ..models.model_employee import set_permissions
 
 
 class TestModelEmployee(TestCase):
 
     def setUp(self):
         self.user = self.make_user()
-        self.employee = Employee.objects.create(cpf="974.220.200-16", user=self.user, departament=Employee.NEUROLOGY)
+        self.employee = Employee.objects.create(
+            cpf="974.220.200-16",
+            user=self.user,
+            departament=Employee.NEUROLOGY
+        )
 
     def test_get_absolute_url(self):
         self.assertEqual(
@@ -23,7 +28,10 @@ class TestModelEmployee(TestCase):
 
     def test_delete_cascade(self):
 
-        self.assertEquals(Employee.objects.get(cpf="974.220.200-16"), self.employee)
+        self.assertEquals(
+            Employee.objects.get(cpf="974.220.200-16"),
+            self.employee
+        )
 
         self.user.delete()
 
@@ -45,11 +53,40 @@ class TestModelEmployeeNoSetUp(TestCase):
             self.user.groups.get(name=Employee.GROUP_NAME)
 
         # now we add the employee<--->user relation
-        self.employee = Employee.objects.create(cpf="974.220.200-16", user=self.user, departament=Employee.NEUROLOGY)
+        self.employee = Employee.objects.create(
+            cpf="974.220.200-16",
+            user=self.user,
+            departament=Employee.NEUROLOGY
+        )
 
-        # it should create the group
+        # it should create the group with permissons
         employee_group = Group.objects.get(name=Employee.GROUP_NAME)
+
+        mock_group = Group.objects.create(name="mock")
+
+        set_permissions(
+            Patient,
+            mock_group,
+            change=True,
+            add=True
+        )
+
+        set_permissions(
+            Responsible,
+            mock_group,
+            change=True,
+            add=True
+        )
+
+        self.assertEqual(
+            employee_group.permissions,
+            employee_group.permissions
+        )
 
         # and change things in the user
         self.assertEquals(self.user.is_staff, True)
-        self.assertEqual(self.user.groups.get(name=Employee.GROUP_NAME), employee_group)
+
+        self.assertEqual(
+            self.user.groups.get(name=Employee.GROUP_NAME),
+            employee_group
+        )


### PR DESCRIPTION
Este PR resolve um erro no painel de admin relacionado ao modelo Employee e também insere o código que adiciona as permissões de ver e editar Patient e Responsible no grupo Employee.
 
## Descrição
<!--- Decreva suas alterações detalhadamente -->
Correção de erro no admin.py: o modelo employee não estava sendo registrado.

Adição de permissões: conforme conversado em https://github.com/fga-gpp-mds/2018.1-Dr-Down/pull/91

## Motivação e Contexto
<!--- Por que essa mudança é necessária? Qual problema ela resolve? -->
Esta mudanças visam complementar a história de Employee da sprint passada.

## Como Isso Foi Testado?
<!--- Por favor, descreva detalhadamente como você testou suas mudanças. -->
<!--- Inclua detalhes do seu ambiente de teste e os testes que você executou -->
<!--- para ver como a sua alteração afeta outras áreas do código, etc. -->
As mudanças foram testadas por mim através do uso da aplicação e também através de testes unitários.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [X] Meu código segue o estilo de código desse projeto.
- [X] Meus _commits_ seguem o padrão de estilo desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [X] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [X] Eu adicionei testes para cobrir minhas mudanças.
- [X] Todos os testes novos e existentes passaram.