### PR TITLE
TS62 - Inconsistência na especialização do usuário

### DIFF
--- a/drdown/users/admin.py
+++ b/drdown/users/admin.py
@@ -12,10 +12,6 @@ from .models import (
         Doctor
     )
 
-admin.site.register(Doctor)
-admin.site.register(Patient)
-admin.site.register(Responsible)
-
 
 class MyUserChangeForm(UserChangeForm):
     class Meta(UserChangeForm.Meta):
@@ -47,10 +43,46 @@ class MyUserAdmin(AuthUserAdmin):
     fieldsets = (
             ('User Profile', {'fields': ('name',)}),
     ) + AuthUserAdmin.fieldsets
-    list_display = ('username', 'name', 'is_superuser')
+    list_display = ('username','has_specialization', 'name', 'is_superuser')
     search_fields = ['name']
 
 
 @admin.register(Employee)
 class EmployeeAdmin(admin.ModelAdmin):
     change_form_template = "admin/change_form.html"
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # This is the case when obj is already created i.e. it's an edit
+            return ['user']
+        else:
+            return []
+
+
+@admin.register(Responsible)
+class ResponsibleAdmin(admin.ModelAdmin):
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # This is the case when obj is already created i.e. it's an edit
+            return ['user']
+        else:
+            return []
+
+
+@admin.register(Doctor)
+class DoctorAdmin(admin.ModelAdmin):
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # This is the case when obj is already created i.e. it's an edit
+            return ['user']
+        else:
+            return []
+
+
+@admin.register(Patient)
+class PatientAdmin(admin.ModelAdmin):
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # This is the case when obj is already created i.e. it's an edit
+            return ['user']
+        else:
+            return []

--- a/drdown/users/admin.py
+++ b/drdown/users/admin.py
@@ -52,37 +52,45 @@ class EmployeeAdmin(admin.ModelAdmin):
     change_form_template = "admin/change_form.html"
 
     def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
         if obj:  # This is the case when obj is already created i.e. it's an edit
-            return ['user']
-        else:
-            return []
+            fields += ("user",)
+
+        return fields
 
 
 @admin.register(Responsible)
 class ResponsibleAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
         if obj:  # This is the case when obj is already created i.e. it's an edit
-            return ['user']
-        else:
-            return []
+            fields += ("user",)
+
+        return fields
 
 
 @admin.register(Doctor)
 class DoctorAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
         if obj:  # This is the case when obj is already created i.e. it's an edit
-            return ['user']
-        else:
-            return []
+            fields += ("user",)
+
+        return fields
 
 
 @admin.register(Patient)
 class PatientAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+
         if obj:  # This is the case when obj is already created i.e. it's an edit
-            return ['user']
-        else:
-            return []
+            fields += ("user",)
+
+        return fields

--- a/drdown/users/models/model_doctor.py
+++ b/drdown/users/models/model_doctor.py
@@ -96,6 +96,7 @@ class Doctor(models.Model):
         # TODO: add permissions to edit Patient and Parent when they get ready
         self.user.groups.add(doctor_group)
 
+        self.user.clean()
         self.user.save()
 
         self.clean()
@@ -106,7 +107,8 @@ class Doctor(models.Model):
         return self.user.get_username() + " - " + self.get_speciality_display()
 
     def delete(self, *args, **kwargs):
-
+        self.user.has_specialization = False
+        self.user.save()
         User.remove_staff(self.user)
         super().delete(*args, **kwargs)
 
@@ -114,8 +116,3 @@ class Doctor(models.Model):
         verbose_name = _('Doctor')
         verbose_name_plural = _('Doctors')
 
-
-@receiver(post_delete, sender=Doctor)
-def remove_specialization(sender, instance, *args, **kwargs):
-    if instance.user.has_specialization:
-        instance.user.has_specialization = False

--- a/drdown/users/models/model_employee.py
+++ b/drdown/users/models/model_employee.py
@@ -120,6 +120,7 @@ class Employee(models.Model):
 
         self.user.groups.add(employee_group)
 
+        self.user.clean()
         self.user.save()
 
         self.clean()
@@ -127,20 +128,14 @@ class Employee(models.Model):
         super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-
+        self.user.has_specialization = False
+        self.user.save()
         User.remove_staff(self.user)
         super().delete(*args, **kwargs)
 
     class Meta:
         verbose_name = _('Employee')
         verbose_name_plural = _('Employees')
-
-
-@receiver(post_delete, sender=Employee)
-def remove_specialization(sender, instance, *args, **kwargs):
-    if instance.user.has_specialization:
-        instance.user.has_specialization = False
-
 
 def set_permissions(model, group, change=False, add=False, delete=False):
     content_type = ContentType.objects.get_for_model(model)

--- a/drdown/users/models/model_patient.py
+++ b/drdown/users/models/model_patient.py
@@ -111,11 +111,13 @@ class Patient(models.Model):
         self.user.clean()
 
     def save(self, *args, **kwargs):
+        self.user.clean()
+        self.user.save()
         self.clean()
         super().save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        self.user.has_specialization = False
+        self.user.save()
+        super().delete(*args, **kwargs)
 
-@receiver(post_delete, sender=Patient)
-def remove_specialization(sender, instance, *args, **kwargs):
-    if instance.user.has_specialization:
-        instance.user.has_specialization = False

--- a/drdown/users/models/model_responsible.py
+++ b/drdown/users/models/model_responsible.py
@@ -40,14 +40,15 @@ class Responsible(models.Model):
         self.user.clean()
 
     def save(self, *args, **kwargs):
+        self.user.clean()
+        self.user.save()
         self.clean()  # enforce model validation
         super().save(*args, **kwargs)
 
     def __str__(self):
         return self.user.get_username()
 
-
-@receiver(post_delete, sender=Responsible)
-def remove_specialization(sender, instance, *args, **kwargs):
-    if instance.user.has_specialization:
-        instance.user.has_specialization = False
+    def delete(self, *args, **kwargs):
+        self.user.has_specialization = False
+        self.user.save()
+        super().delete(*args, **kwargs)

--- a/drdown/users/models/model_user.py
+++ b/drdown/users/models/model_user.py
@@ -121,5 +121,4 @@ class User(AbstractUser):
         return data
 
     def save(self, *args, **kwargs):
-        self.clean()
         super().save(*args, **kwargs)

--- a/drdown/users/tests/test_model_doctor.py
+++ b/drdown/users/tests/test_model_doctor.py
@@ -155,7 +155,10 @@ class ModelTestCase(TestCase):
 
         self.assertNotEquals(self.doctor1.speciality, Doctor.CARDIOLOGY)
 
-    def teste_readonly_user(self):
+    def test_readonly_user(self):
+        """
+        Test is user field is read_only after creation of an doctor
+        """
 
         self.user = self.make_user()
 

--- a/drdown/users/tests/test_model_doctor.py
+++ b/drdown/users/tests/test_model_doctor.py
@@ -1,4 +1,5 @@
 from test_plus.test import TestCase
+from ..admin import DoctorAdmin
 from django.contrib.auth.models import Group
 
 
@@ -153,3 +154,36 @@ class ModelTestCase(TestCase):
         """
 
         self.assertNotEquals(self.doctor1.speciality, Doctor.CARDIOLOGY)
+
+    def teste_readonly_user(self):
+
+        self.user = self.make_user()
+
+        ma = DoctorAdmin(model=Doctor, admin_site=None)
+
+        self.assertEqual(
+            hasattr(self.user, 'doctor'),
+            False
+        )
+        # since there is no atribute patient in self user, we
+        # can assume that obj=None
+        self.assertEqual(
+            list(ma.get_readonly_fields(self, obj=None)),
+            []
+        )
+
+        self.doctor = Doctor.objects.create(
+            cpf="057.641.271-65",
+            user=self.user,
+            speciality=Doctor.NEUROLOGY)
+
+        self.assertEqual(
+            hasattr(self.user, 'doctor'),
+            True
+        )
+
+        ma1 = DoctorAdmin(model=Doctor, admin_site=None)
+        self.assertEqual(
+            list(ma1.get_readonly_fields(self, obj=self.user.doctor)),
+            ['user']
+        )

--- a/drdown/users/tests/test_model_employee.py
+++ b/drdown/users/tests/test_model_employee.py
@@ -147,7 +147,10 @@ class TestModelEmployeeNoSetUp(TestCase):
             transform=lambda x: x
         )
 
-    def teste_readonly_user(self):
+    def test_readonly_user(self):
+        """
+        Test is user field is read_only after creation of an employee
+        """
 
         self.user = self.make_user()
 

--- a/drdown/users/tests/test_model_employee.py
+++ b/drdown/users/tests/test_model_employee.py
@@ -1,7 +1,6 @@
 from test_plus.test import TestCase
 from django.contrib.auth.models import Group, Permission, ContentType
-
-
+from ..admin import EmployeeAdmin
 from ..models import Employee, Patient, Responsible
 from ..models.model_employee import set_permissions
 
@@ -129,7 +128,7 @@ class TestModelEmployeeNoSetUp(TestCase):
 
         # this will be tested with the Patient model
         content_type = ContentType.objects.get_for_model(Patient)
- 
+
         mock_group = Group.objects.create(name="mock")
 
         # adds all permissions avaliable in set_permissions
@@ -143,7 +142,41 @@ class TestModelEmployeeNoSetUp(TestCase):
 
         # check if the where added
         self.assertQuerysetEqual(
-            Permission.objects.filter(content_type=content_type), 
+            Permission.objects.filter(content_type=content_type),
             mock_group.permissions.all(),
             transform=lambda x: x
+        )
+
+    def teste_readonly_user(self):
+
+        self.user = self.make_user()
+
+        ma = EmployeeAdmin(model=Employee, admin_site=None)
+
+        self.assertEqual(
+            hasattr(self.user, 'employee'),
+            False
+        )
+        # since there is no atribute employee in self user, we
+        # can assume that obj=None
+        self.assertEqual(
+            list(ma.get_readonly_fields(self, obj=None)),
+            []
+        )
+
+        self.employee = Employee.objects.create(
+            cpf="974.220.200-16",
+            user=self.user,
+            departament=Employee.NEUROLOGY
+        )
+
+        self.assertEqual(
+            hasattr(self.user, 'employee'),
+            True
+        )
+
+        ma1 = EmployeeAdmin(model=Employee, admin_site=None)
+        self.assertEqual(
+            list(ma1.get_readonly_fields(self, obj=self.user.employee)),
+            ['user']
         )

--- a/drdown/users/tests/test_model_patient.py
+++ b/drdown/users/tests/test_model_patient.py
@@ -66,7 +66,10 @@ class TestModelPatient(TestCase):
             self.user.get_username()
         )
 
-    def teste_readonly_user(self):
+    def test_readonly_user(self):
+        """
+        Test is user field is read_only after creation of an patient
+        """
 
         ma = PatientAdmin(model=Patient, admin_site=None)
 

--- a/drdown/users/tests/test_model_patient.py
+++ b/drdown/users/tests/test_model_patient.py
@@ -1,5 +1,5 @@
 from test_plus.test import TestCase
-
+from ..admin import PatientAdmin
 from ..models import Patient
 
 
@@ -65,3 +65,26 @@ class TestModelPatient(TestCase):
             self.patient.__str__(),
             self.user.get_username()
         )
+
+    def teste_readonly_user(self):
+
+        ma = PatientAdmin(model=Patient, admin_site=None)
+
+        # since there is no atribute patient in self user, we
+        # can assume that obj=None
+        self.assertEqual(
+            list(ma.get_readonly_fields(self, obj=None)),
+            []
+        )
+
+        self.assertEqual(
+            hasattr(self.user, 'patient'),
+            True
+        )
+
+        ma1 = PatientAdmin(model=Patient, admin_site=None)
+        self.assertEqual(
+            list(ma1.get_readonly_fields(self, obj=self.user.patient)),
+            ['user']
+        )
+

--- a/drdown/users/tests/test_model_responsible.py
+++ b/drdown/users/tests/test_model_responsible.py
@@ -1,4 +1,5 @@
 from test_plus.test import TestCase
+from ..admin import ResponsibleAdmin
 from django.core.exceptions import ValidationError
 
 from ..models import Responsible, Patient
@@ -92,3 +93,25 @@ class TestModelResponsible(TestCase):
                 patient=self.patient,
                 user=self.user_2
             )
+
+    def teste_readonly_user(self):
+
+        ma = ResponsibleAdmin(model=Responsible, admin_site=None)
+
+        # since there is no atribute patient in self user, we
+        # can assume that obj=None
+        self.assertEqual(
+            list(ma.get_readonly_fields(self, obj=None)),
+            []
+        )
+
+        self.assertEqual(
+            hasattr(self, 'responsible'),
+            True
+        )
+
+        ma1 = ResponsibleAdmin(model=Responsible, admin_site=None)
+        self.assertEqual(
+            list(ma1.get_readonly_fields(self, obj=self.responsible)),
+            ['user']
+        )

--- a/drdown/users/tests/test_model_responsible.py
+++ b/drdown/users/tests/test_model_responsible.py
@@ -94,7 +94,10 @@ class TestModelResponsible(TestCase):
                 user=self.user_2
             )
 
-    def teste_readonly_user(self):
+    def test_readonly_user(self):
+        """
+        Test is user field is read_only after creation of an responsible
+        """
 
         ma = ResponsibleAdmin(model=Responsible, admin_site=None)
 

--- a/drdown/users/tests/test_model_user.py
+++ b/drdown/users/tests/test_model_user.py
@@ -565,6 +565,112 @@ class TestField(TestCase):
             employee.user=self.user2
             employee.save()
 
+    def test_delete_employee_specialization(self):
+        """
+        update this
+        """
+
+        self.assertEqual(self.user1.has_specialization, False)
+
+        employee=Employee.objects.create(
+            cpf="974.220.200-16",
+            user=self.user1,
+            departament=Employee.NEUROLOGY
+        )
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'employee'), True)
+        self.assertEqual(self.user1.has_specialization, True)
+
+        employee.delete()
+        self.assertEqual(self.user1.has_specialization, False)
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'employee'), False)
+        self.assertEqual(self.user1.has_specialization, False)
+
+    def test_delete_patient_specialization(self):
+        """
+        update this
+        """
+
+        self.assertEqual(self.user1.has_specialization, False)
+
+        patient = Patient.objects.create(
+            ses="1234567",
+            user=self.user1,
+            priority=1,
+            mother_name="Mãe",
+            father_name="Pai",
+            ethnicity=3,
+            sus_number="12345678911",
+            civil_registry_of_birth="12345678911",
+            declaration_of_live_birth="12345678911"
+        )
+        self.assertEqual(hasattr(self.user1, 'patient'), True)
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'patient'), True)
+        self.assertEqual(self.user1.has_specialization, True)
+
+        patient.delete()
+        self.assertEqual(self.user1.has_specialization, False)
+
+        self.user1.refresh_from_db()
 
 
+        self.assertEqual(hasattr(self.user1, 'patient'), False)
+        self.assertEqual(self.user1.has_specialization, False)
 
+    def test_delete_responsible_specialization(self):
+        """
+        update this
+        """
+
+        self.assertEqual(self.user1.has_specialization, False)
+
+        responsible=Responsible.objects.create(
+            cpf="974.220.200-16",
+            user=self.user1,
+        )
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'responsible'), True)
+        self.assertEqual(self.user1.has_specialization, True)
+
+        responsible.delete()
+        self.assertEqual(self.user1.has_specialization, False)
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'responsible'), False)
+        self.assertEqual(self.user1.has_specialization, False)
+
+    def test_doctor_responsible_specialization(self):
+        """
+        update this
+        """
+
+        self.assertEqual(self.user1.has_specialization, False)
+
+        doctor = Doctor.objects.create(
+            cpf="507.522.730-94",
+            user=self.user1,
+            speciality=Doctor.NEUROLOGY
+        )
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'doctor'), True)
+        self.assertEqual(self.user1.has_specialization, True)
+
+        doctor.delete()
+        self.assertEqual(self.user1.has_specialization, False)
+
+        self.user1.refresh_from_db()
+
+        self.assertEqual(hasattr(self.user1, 'doctor'), False)
+        self.assertEqual(self.user1.has_specialization, False)

--- a/drdown/users/tests/test_model_user.py
+++ b/drdown/users/tests/test_model_user.py
@@ -567,7 +567,9 @@ class TestField(TestCase):
 
     def test_delete_employee_specialization(self):
         """
-        update this
+        Test that checks if the bool has_specialization goes true when
+        an employee is created and if that bool returns to false in the
+        employee deletion
         """
 
         self.assertEqual(self.user1.has_specialization, False)
@@ -593,7 +595,9 @@ class TestField(TestCase):
 
     def test_delete_patient_specialization(self):
         """
-        update this
+        Test that checks if the bool has_specialization goes true when
+        an patient is created and if that bool returns to false in the
+        patient deletion
         """
 
         self.assertEqual(self.user1.has_specialization, False)
@@ -626,7 +630,9 @@ class TestField(TestCase):
 
     def test_delete_responsible_specialization(self):
         """
-        update this
+        Test that checks if the bool has_specialization goes true when
+        an responsible is created and if that bool returns to false in the
+        responsible deletion
         """
 
         self.assertEqual(self.user1.has_specialization, False)
@@ -649,9 +655,11 @@ class TestField(TestCase):
         self.assertEqual(hasattr(self.user1, 'responsible'), False)
         self.assertEqual(self.user1.has_specialization, False)
 
-    def test_doctor_responsible_specialization(self):
+    def test_delete_doctor_specialization(self):
         """
-        update this
+        Test that checks if the bool has_specialization goes true when
+        an doctor is created and if that bool returns to false in the
+        doctor deletion
         """
 
         self.assertEqual(self.user1.has_specialization, False)


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição

- Correção no bug que tornava a criação e deleção de usuários especializados inconsistente.

- Alteração no Django Admin para que após a especialização de um usuário esse não possar ter seu usuário alterado.

## _Issue_ Relacionada
#135 

## Motivação e Contexto
Garantir que ao especializar um usuário esse não seja mais listado como possível usuário a ser especializado e garantir também que ao excluir essa especialização o usuário possa ser especializado novamente.

## Como Isso Foi Testado?
Através de testes unitários.

## Capturas de Tela (se apropriado):
Tela mostrando que um usuário especializado não pode mais ter seu user alterado.
![screenshot_20180415_142535](https://user-images.githubusercontent.com/3029276/38781303-0d20f274-40b9-11e8-8813-d95c0f37fa1d.png)

Tela mostrando que o usuário especializado anteriormente possui especialização (has_specialization = True)
![screenshot_20180415_142603](https://user-images.githubusercontent.com/3029276/38781313-1d5125c4-40b9-11e8-8ed8-8045ee1190a2.png)

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [X] Meu código segue o estilo de código desse projeto.
- [X] Meus _commits_ seguem o padrão de estilo desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [X] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [X] Eu adicionei testes para cobrir minhas mudanças.
- [X] Todos os testes novos e existentes passaram.