### PR TITLE
[HOTFIX]Travis SSL bug

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
   # CFFI dependencies
-  && apk add libffi-dev openssl-dev py-cffi \
+  && apk add libffi-dev py-cffi \
   # Translations dependencies
   && apk add gettext \
   # https://docs.djangoproject.com/en/2.0/ref/django-admin/#dbshell


### PR DESCRIPTION
As máquinas do Travis estão dando erro no build devido a uma concorrência de dependências do OpenSSL e o LibreSSL, foi removido a instalação do OpenSSL no Dockerfile já que as máquinas são alpine e vem com LibreSSL já instalado devido a sua compilação.

## Descrição
Corrige o bug mencionado acima

## _Issue_ Relacionada
Não se aplica.

## Motivação e Contexto
Evitar erros de construção que impossibilitariam o pipeline contínuo

## Como Isso Foi Testado?
Foi feito testes de build no Travis com a branch que tinha o hotfix

## Capturas de Tela (se apropriado):
Não se aplica.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Meu código segue o estilo de código desse projeto.
- [x] Meus _commits_ seguem o padrão de estilo desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.